### PR TITLE
TR-722

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :document_number
+  attributes :id, :email, :document_number, :first_name, :last_name
 end


### PR DESCRIPTION
## JIRA Card
https://widergy.atlassian.net/browse/TR-722

## Summary
Se corrigió un Bug por el cual no se mandaban los atributos first_name y last_name en la resppuestas del endpoint [Show Current](https://widergytraininguguitoapi.docs.apiary.io/#reference/a.-usuarios/show-current/show-current)

Lo que sucedió es que estos atributos no se encontraban en UserSerializer, por lo que se los agregué.

## Screenshots

![image](https://github.com/user-attachments/assets/451a7355-4786-4fd2-918f-af7ecf4d2005)

## Test Cases
Para testearlo se puede probar el endpoint con cualquier usuario que tenga registrado nombre y apellido