### PR TITLE
feat: [TR-727] authentication note controller

### DIFF
--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -28,9 +28,9 @@ module Api
       end
 
       def note
-        user_notes(params[:id])
+        user_notes.find(params[:id])
       end
-      
+
       def user_notes
         current_user.notes
       end

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class NotesController < ApplicationController
+      before_action :authenticate_user!
       before_action :validate_type, only: [:index]
       def index
         render json: ordered_notes, status: :ok, each_serializer: IndexNoteSerializer
@@ -17,11 +18,15 @@ module Api
       end
 
       def find_notes
-        Note.where(note_type: params[:type])
+        notes.where(note_type: params[:type])
       end
 
       def find_note
-        Note.find(params[:id])
+        notes.find(params[:id])
+      end
+
+      def notes
+        current_user.notes
       end
 
       def validate_type
@@ -30,7 +35,8 @@ module Api
       end
 
       def render_error(_msg)
-        render json: {message: I18n.t('activerecord.errors.models.note.invalid_type')}, status: :bad_request
+        render json: { message: I18n.t('activerecord.errors.models.note.invalid_type') },
+               status: :bad_request
       end
     end
   end


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/TR-727

## Summary

Se agrega autenticación al controller de Notes, por lo que el usuario necesita autenticarse antes de utilizar los endpoints de  `index` y `show`

## Screenshots

Servicios funcionando con autenticación
<img width="836" alt="image" src="https://github.com/user-attachments/assets/6da89b69-8d69-48de-bbe5-528f88ca3afb" />

<img width="842" alt="image" src="https://github.com/user-attachments/assets/0fbf3ac1-1ab7-43a2-af29-fe0e659eb76f" />


Sin autenticación devuelve 401
<img width="853" alt="image" src="https://github.com/user-attachments/assets/b280444a-89ad-49db-b212-6bd7db8fa592" />
<img width="850" alt="image" src="https://github.com/user-attachments/assets/6ddeffa4-2ab6-4d89-a3ba-a04ebbe5f7c3" />


Info del current_user
<img width="565" alt="image" src="https://github.com/user-attachments/assets/8acd7531-0d29-40a5-856d-625cf9b19c56" />


JWT decodificado
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/a7502bf1-fe4e-4697-981b-16b793b532f7" />


Como se ve en las imagenes, el JWT tiene únicamente los datos indispensables para autenticar al usuario, el algoritmo de codificación, el id, etc. Mientras que el resto de información se queda en el backend, en el objeto `current_user`.

De esta forma evitamos exponer datos sensibles de los usuarios en la Web y forzamos que tenga que consultar al back para obtener la información, lo que nos da más control a nosotros.

## Test Cases

Probar los endpoints con y sin autenticación y con varios usuarios.